### PR TITLE
feat: Finish forgot password screen successfully.

### DIFF
--- a/lib/config/routing/route_generator.dart
+++ b/lib/config/routing/route_generator.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:online_exam/features/main_layout/main_layout.dart';
+import 'package:online_exam/features/auth/presentation/manager/auth_cubit.dart';
 import 'package:online_exam/features/auth/presentation/manager/signUp/sign_up_cubit.dart';
 import 'package:online_exam/features/auth/presentation/pages/sign_up_screen.dart';
-import 'package:online_exam/features/auth/presentation/manager/auth_cubit.dart';
 import 'package:online_exam/features/main_layout/main_layout.dart';
 import 'package:online_exam/features/specific_exam/presentation/pages/specific_exam.dart';
 import 'package:online_exam/features/subject_exams/domain/entities/exams_on_subject_entity.dart';
 import 'package:online_exam/features/subject_exams/presentation/pages/subject_exams_screen.dart';
+
 import '../../core/di/di.dart';
+import '../../features/auth/presentation/pages/forget_password_screen.dart';
 import '../../features/auth/presentation/pages/sign_in_screen.dart';
 import '../../features/main_layout/explore/domain/entities/subject_entity.dart';
 import 'app_routes.dart';
@@ -32,8 +33,8 @@ class RouteGenerator {
           ),
         );
 
-      // case AppRoutes.forgetPasswordRoute:
-      //   return MaterialPageRoute(builder: (_) => const ForgetPasswordScreen());
+      case AppRoutes.forgetPasswordRoute:
+        return MaterialPageRoute(builder: (_) => const ForgetPasswordScreen());
 
       case AppRoutes.mainLayout:
         return MaterialPageRoute(builder: (context) => const MainLayout());

--- a/lib/config/theme/app_theme.dart
+++ b/lib/config/theme/app_theme.dart
@@ -21,6 +21,7 @@ abstract class AppTheme {
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
+          minimumSize: const Size(double.infinity, 50),
           disabledBackgroundColor: AppColors.black[30],
           disabledForegroundColor: AppColors.white,
           backgroundColor: AppColors.blue[0],
@@ -122,20 +123,10 @@ abstract class AppTheme {
               color: AppColors.black,
               fontWeight: AppFontWeight.regular
           ),
-          displayMedium: TextStyle(
-              fontSize: 18.sp,
-              fontWeight: AppFontWeight.medium,
-              color: AppColors.black
-          ),
-          displaySmall: TextStyle(
-              fontSize: 13.sp,
-              fontWeight: AppFontWeight.regular,
-              color: AppColors.black
-          ),
-          headlineLarge: TextStyle(
-              color: AppColors.black,
-              fontWeight: AppFontWeight.semiBold,
-              fontSize: 20.sp
+          displayLarge: TextStyle(
+            fontSize: 18.sp,
+            fontWeight: AppFontWeight.medium,
+            color: AppColors.black,
           )
       ),
     );

--- a/lib/config/theme/colors.dart
+++ b/lib/config/theme/colors.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 abstract class AppColors {
-  static const Color white = Color(0xfff9f9f9);
+  static const Color white = Color(0xffF9F9F9);
 
   static const Color white2 = Color(0xffffffff);
 
@@ -18,6 +18,8 @@ abstract class AppColors {
   static const Color lightGreen = Color(0xffCAF9CC);
 
   static const Color hintColor = Color(0xffA6A6A6);
+
+  static const Color otpFieldBorderColor = Color(0xffDFE7F7);
 
   static const MaterialColor blue = MaterialColor(0xFF02369C, <int, Color>{
     0: Color(0xFF02369C), // base color

--- a/lib/core/helpers/dialogue_utils.dart
+++ b/lib/core/helpers/dialogue_utils.dart
@@ -74,9 +74,13 @@ abstract class DialogueUtils {
       context: context,
       builder: (context) {
         return AlertDialog(
-          content: Text(message),
+          content: Text(message, style: TextStyle(
+            fontSize: 16.sp,
+            fontWeight: FontWeight.w500,
+            color: AppColors.black,
+          ),),
           title: Text(title ?? "", style: TextStyle(
-            fontSize: 14.sp,
+            fontSize: 20.sp,
             fontWeight: FontWeight.w500,
             color: AppColors.blue[70],
           )),

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -18,24 +18,31 @@
   "confirm_password": "Confirm password",
   "enter_phone_number": "Enter phone number",
   "phone_number": "Phone number",
-  "sign_up_button" :  "Signup",
+  "sign_up_button": "Signup",
   "already_have_an_account": "Already have an account?",
-  "ok" : "OK",
+  "ok": "OK",
   "acount_created_successfully": "Account created successfully",
-  "success" : "Success",
+  "success": "Success",
   "no_internet_connection": "No internet connection",
   "loading": "Loading...",
   "error": "Error",
   "login_successfully": "Login successfully",
-  "survey" : "Survey",
-  "search" : "Search",
-  "browse_by_subject" : "Browse by subject",
-  "explore" : "Explore",
-  "result" : "Result",
-  "profile" : "Profile"
+  "survey": "Survey",
+  "search": "Search",
+  "browse_by_subject": "Browse by subject",
+  "explore": "Explore",
+  "result": "Result",
+  "profile": "Profile",
+  "reset_password": "Reset password",
+  "password_validation": "Password must not be empty and must contain\n6 characters with upper case letter and one\nnumber at least",
+  "resend": " Resend",
+  "didnt_receive_code": "Didn't receive code?",
+  "enter_verification_code": "Please enter your code that send to your\nemail address",
+  "email_verification": "Email verification",
+  "invalid_email": "This Email is not valid",
+  "enter_associated_email": "Please enter your email associated to\nyour account",
+  "continue_word": "Continue",
+  "new_password": "New password",
+  "invalid_code": "Invalid code",
+  "code_resend_successfully": "Code resent successfully"
 }
-
- 
-  
-
-

--- a/lib/core/l10n/translations/app_localizations.dart
+++ b/lib/core/l10n/translations/app_localizations.dart
@@ -297,6 +297,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Profile'**
   String get profile;
+
+  /// No description provided for @reset_password.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset password'**
+  String get reset_password;
+
+  /// No description provided for @password_validation.
+  ///
+  /// In en, this message translates to:
+  /// **'Password must not be empty and must contain\n6 characters with upper case letter and one\nnumber at least'**
+  String get password_validation;
+
+  /// No description provided for @resend.
+  ///
+  /// In en, this message translates to:
+  /// **' Resend'**
+  String get resend;
+
+  /// No description provided for @didnt_receive_code.
+  ///
+  /// In en, this message translates to:
+  /// **'Didn\'t receive code?'**
+  String get didnt_receive_code;
+
+  /// No description provided for @enter_verification_code.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your code that send to your\nemail address'**
+  String get enter_verification_code;
+
+  /// No description provided for @email_verification.
+  ///
+  /// In en, this message translates to:
+  /// **'Email verification'**
+  String get email_verification;
+
+  /// No description provided for @invalid_email.
+  ///
+  /// In en, this message translates to:
+  /// **'This Email is not valid'**
+  String get invalid_email;
+
+  /// No description provided for @enter_associated_email.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your email associated to\nyour account'**
+  String get enter_associated_email;
+
+  /// No description provided for @continue_word.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get continue_word;
+
+  /// No description provided for @new_password.
+  ///
+  /// In en, this message translates to:
+  /// **'New password'**
+  String get new_password;
+
+  /// No description provided for @invalid_code.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid code'**
+  String get invalid_code;
+
+  /// No description provided for @code_resend_successfully.
+  ///
+  /// In en, this message translates to:
+  /// **'Code resent successfully'**
+  String get code_resend_successfully;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/core/l10n/translations/app_localizations_en.dart
+++ b/lib/core/l10n/translations/app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -109,4 +110,43 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get profile => 'Profile';
+
+  @override
+  String get reset_password => 'Reset password';
+
+  @override
+  String get password_validation =>
+      'Password must not be empty and must contain\n6 characters with upper case letter and one\nnumber at least';
+
+  @override
+  String get resend => ' Resend';
+
+  @override
+  String get didnt_receive_code => 'Didn\'t receive code?';
+
+  @override
+  String get enter_verification_code =>
+      'Please enter your code that send to your\nemail address';
+
+  @override
+  String get email_verification => 'Email verification';
+
+  @override
+  String get invalid_email => 'This Email is not valid';
+
+  @override
+  String get enter_associated_email =>
+      'Please enter your email associated to\nyour account';
+
+  @override
+  String get continue_word => 'Continue';
+
+  @override
+  String get new_password => 'New password';
+
+  @override
+  String get invalid_code => 'Invalid code';
+
+  @override
+  String get code_resend_successfully => 'Code resent successfully';
 }

--- a/lib/core/network/api_constants.dart
+++ b/lib/core/network/api_constants.dart
@@ -2,8 +2,10 @@ abstract class ApiConstants {
   static const String baseUrl = "https://exam.elevateegy.com/api/v1/";
   static const String signInEndpoint = "auth/signin";
   static const String signUpEndpoint = "auth/signup";
-  static const String forgetPasswordEndpoint = "auth/signup";
+  static const String forgetPasswordEndpoint = "auth/forgotPassword";
   static const String getSubjectsEndpoint = "subjects";
   static const String token = "token";
   static const String getAllSubjectsExamsOnSubjectEndpoint = "exams";
+  static const String verifyResetCodeEndpoint = "auth/verifyResetCode";
+  static const String resetPasswordEndpoint = "auth/resetPassword";
 }

--- a/lib/core/network/api_services.dart
+++ b/lib/core/network/api_services.dart
@@ -7,6 +7,13 @@ import 'package:online_exam/features/auth/data/models/userModel/user_model.dart'
 import 'package:online_exam/features/main_layout/explore/data/models/subjects_dto/subjects_dto.dart';
 import 'package:online_exam/features/subject_exams/data/model/get_exams_on_subject_dto.dart';
 import 'package:retrofit/retrofit.dart';
+
+import '../../features/auth/data/models/forget_password/email_verification_input_model.dart';
+import '../../features/auth/data/models/forget_password/forget_password_input_model.dart';
+import '../../features/auth/data/models/forget_password/forget_password_response_dto.dart';
+import '../../features/auth/data/models/forget_password/reset_password_input_model.dart';
+import '../../features/auth/data/models/forget_password/reset_password_response_dto.dart';
+import '../../features/auth/data/models/forget_password/verify_reset_code_response_dto.dart';
 import '../../features/auth/data/models/login/login_request.dart';
 import 'api_constants.dart';
 
@@ -23,10 +30,21 @@ abstract class ApiServices {
   @POST(ApiConstants.signUpEndpoint)
   Future<UserModelDto> signUp(@Body() RegisterInputModel registerInputModel);
   @GET(ApiConstants.getSubjectsEndpoint)
-  Future<SubjectsDto> getSubjects(@Header(ApiConstants.token) String token);
+  Future<SubjectsDto> getSubjects();
 
   @GET(ApiConstants.getAllSubjectsExamsOnSubjectEndpoint)
   Future<GetExamsOnSubjectDto> getExamsOnSubject(
-      @Header(AppConstants.token) String token,
       @Query(AppConstants.subject) String subjectId);
+
+  @POST(ApiConstants.forgetPasswordEndpoint)
+  Future<ForgetPasswordResponseDto> requestPasswordReset(
+      @Body() ForgetPasswordInputModel body);
+
+  @POST(ApiConstants.verifyResetCodeEndpoint)
+  Future<VerifyResetCodeResponseDto> confirmCode(
+      @Body() EmailVerificationInputModel resetCode);
+
+  @PUT(ApiConstants.resetPasswordEndpoint)
+  Future<ResetPasswordResponseDto> resetPassword(
+      @Body() ResetPasswordInputModel forgetPasswordInputModel);
 }

--- a/lib/core/network/di.dart
+++ b/lib/core/network/di.dart
@@ -1,17 +1,22 @@
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
+import 'package:online_exam/core/helpers/shared_pref.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 import '../di/di.dart';
+import '../utils/app_constants.dart';
 import 'api_constants.dart';
 
 @module
 abstract class DioModule {
+
   @lazySingleton
   Dio provideDio() {
     Dio dio = Dio();
     dio.options.baseUrl = ApiConstants.baseUrl;
-    dio.options.headers = {'Content-Type': 'application/json'};
+    dio.options.headers = {'Content-Type': 'application/json',
+      AppConstants.token: SharedPrefHelper.getData(key: AppConstants.token) ??
+          ''};
     dio.interceptors.add(getIt.get<PrettyDioLogger>());
     return dio;
   }
@@ -28,3 +33,4 @@ abstract class DioModule {
     );
   }
 }
+

--- a/lib/features/auth/data/data_sources/auth_remote_ds.dart
+++ b/lib/features/auth/data/data_sources/auth_remote_ds.dart
@@ -1,11 +1,27 @@
 import 'package:dartz/dartz.dart';
 import 'package:online_exam/core/errors/failures.dart';
+import 'package:online_exam/features/auth/data/models/forget_password/forget_password_input_model.dart';
 import 'package:online_exam/features/auth/data/models/login/login_request.dart';
 import 'package:online_exam/features/auth/data/models/login/login_response_dm.dart';
 import 'package:online_exam/features/auth/data/models/userInputModels/register_input_model.dart';
 import 'package:online_exam/features/auth/data/models/userModel/user_model.dart';
 
-abstract class AuthRemoteDataSource {
+import '../models/forget_password/email_verification_input_model.dart';
+import '../models/forget_password/forget_password_response_dto.dart';
+import '../models/forget_password/reset_password_input_model.dart';
+import '../models/forget_password/reset_password_response_dto.dart';
+import '../models/forget_password/verify_reset_code_response_dto.dart';
+
+abstract interface class AuthRemoteDataSource {
   Future<Either<Failures, LoginResponseDm>> signIn(LoginRequest loginRequest);
   Future<UserModelDto> signUp(RegisterInputModel registerInputModel);
+
+  Future<ForgetPasswordResponseDto> requestPasswordReset(
+      ForgetPasswordInputModel email);
+
+  Future<VerifyResetCodeResponseDto> confirmCode(
+      EmailVerificationInputModel resetCode);
+
+  Future<ResetPasswordResponseDto> resetPassword(
+      ResetPasswordInputModel resetPasswordInputModel);
 }

--- a/lib/features/auth/data/data_sources/auth_remote_ds_impl.dart
+++ b/lib/features/auth/data/data_sources/auth_remote_ds_impl.dart
@@ -1,20 +1,28 @@
 import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
+import 'package:online_exam/core/helpers/shared_pref.dart';
+import 'package:online_exam/features/auth/data/models/forget_password/forget_password_input_model.dart';
 import 'package:online_exam/features/auth/data/models/userInputModels/register_input_model.dart';
 import 'package:online_exam/features/auth/data/models/userModel/user_model.dart';
+
 import '../../../../core/errors/failures.dart';
 import '../../../../core/network/api_services.dart';
 import '../../../../core/utils/app_constants.dart';
+import '../models/forget_password/email_verification_input_model.dart';
+import '../models/forget_password/forget_password_response_dto.dart';
+import '../models/forget_password/reset_password_input_model.dart';
+import '../models/forget_password/reset_password_response_dto.dart';
+import '../models/forget_password/verify_reset_code_response_dto.dart';
 import '../models/login/login_request.dart';
 import '../models/login/login_response_dm.dart';
 import 'auth_remote_ds.dart';
 
 @Injectable(as: AuthRemoteDataSource)
 class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
-  final ApiServices apiServices;
+  final ApiServices _apiServices;
 
-  AuthRemoteDataSourceImpl(this.apiServices);
+  AuthRemoteDataSourceImpl(this._apiServices);
 
   @override
   Future<Either<Failures, LoginResponseDm>> signIn(
@@ -28,9 +36,10 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
     }
 
     try {
-      var response = await apiServices.signIn(loginRequest);
+      var response = await _apiServices.signIn(loginRequest);
 
       if (response.message == AppConstants.responseSuccess) {
+        SharedPrefHelper.saveData(key: AppConstants.token, val: response.token);
         return Right(response);
       } else {
         return Left(ServerError(errorMessage: response.message ?? ''));
@@ -42,7 +51,29 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
 
   @override
   Future<UserModelDto> signUp(RegisterInputModel registerInputModel) async {
-    UserModelDto userModelDto = await apiServices.signUp(registerInputModel);
+    UserModelDto userModelDto = await _apiServices.signUp(registerInputModel);
     return userModelDto;
   }
+
+  @override
+  Future<VerifyResetCodeResponseDto> confirmCode(
+      EmailVerificationInputModel resetCode) async {
+    return await _apiServices.confirmCode(resetCode);
+  }
+
+  @override
+  Future<ForgetPasswordResponseDto> requestPasswordReset(
+      ForgetPasswordInputModel email) async {
+    return await _apiServices.requestPasswordReset(email);
+  }
+
+  @override
+  Future<ResetPasswordResponseDto> resetPassword(
+      ResetPasswordInputModel resetPasswordInputModel) async {
+    return await _apiServices.resetPassword(resetPasswordInputModel);
+  }
+
+
+
+
 }

--- a/lib/features/auth/data/models/forget_password/email_verification_input_model.dart
+++ b/lib/features/auth/data/models/forget_password/email_verification_input_model.dart
@@ -1,0 +1,7 @@
+class EmailVerificationInputModel {
+  final String code;
+
+  EmailVerificationInputModel({required this.code});
+
+  Map<String, dynamic> toJson() => {'resetCode': code};
+}

--- a/lib/features/auth/data/models/forget_password/forget_password_input_model.dart
+++ b/lib/features/auth/data/models/forget_password/forget_password_input_model.dart
@@ -1,0 +1,7 @@
+class ForgetPasswordInputModel {
+  final String email;
+
+  ForgetPasswordInputModel({required this.email});
+
+  Map<String, dynamic> toJson() => {'email': email};
+}

--- a/lib/features/auth/data/models/forget_password/forget_password_response_dto.dart
+++ b/lib/features/auth/data/models/forget_password/forget_password_response_dto.dart
@@ -1,0 +1,26 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:online_exam/features/auth/domain/entities/forget_password/forget_password_response_entity.dart';
+
+part 'forget_password_response_dto.g.dart';
+
+@JsonSerializable()
+class ForgetPasswordResponseDto {
+  @JsonKey(name: "message")
+  final String? message;
+  @JsonKey(name: "info")
+  final String? info;
+
+  ForgetPasswordResponseDto({this.message, this.info});
+
+  factory ForgetPasswordResponseDto.fromJson(Map<String, dynamic> json) {
+    return _$ForgetPasswordResponseDtoFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() {
+    return _$ForgetPasswordResponseDtoToJson(this);
+  }
+
+  ForgetPasswordResponseEntity toEntity() {
+    return ForgetPasswordResponseEntity(message: message, info: info);
+  }
+}

--- a/lib/features/auth/data/models/forget_password/reset_password_input_model.dart
+++ b/lib/features/auth/data/models/forget_password/reset_password_input_model.dart
@@ -1,0 +1,8 @@
+class ResetPasswordInputModel {
+  final String email;
+  final String confirmPass;
+
+  ResetPasswordInputModel({required this.email, required this.confirmPass});
+
+  Map<String, dynamic> toJson() => {'email': email, 'newPassword': confirmPass};
+}

--- a/lib/features/auth/data/models/forget_password/reset_password_response_dto.dart
+++ b/lib/features/auth/data/models/forget_password/reset_password_response_dto.dart
@@ -1,0 +1,26 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:online_exam/features/auth/domain/entities/forget_password/reset_password_response_entity.dart';
+
+part 'reset_password_response_dto.g.dart';
+
+@JsonSerializable()
+class ResetPasswordResponseDto {
+  @JsonKey(name: "message")
+  final String? message;
+  @JsonKey(name: "token")
+  final String? token;
+
+  ResetPasswordResponseDto({this.message, this.token});
+
+  factory ResetPasswordResponseDto.fromJson(Map<String, dynamic> json) {
+    return _$ResetPasswordResponseDtoFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() {
+    return _$ResetPasswordResponseDtoToJson(this);
+  }
+
+  ResetPasswordResponseEntity toEntity() {
+    return ResetPasswordResponseEntity(message: message, token: token);
+  }
+}

--- a/lib/features/auth/data/models/forget_password/verify_reset_code_response_dto.dart
+++ b/lib/features/auth/data/models/forget_password/verify_reset_code_response_dto.dart
@@ -1,0 +1,24 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:online_exam/features/auth/domain/entities/forget_password/verify_reset_code_response_entity.dart';
+
+part 'verify_reset_code_response_dto.g.dart';
+
+@JsonSerializable()
+class VerifyResetCodeResponseDto {
+  @JsonKey(name: "status")
+  final String? status;
+
+  VerifyResetCodeResponseDto({this.status});
+
+  factory VerifyResetCodeResponseDto.fromJson(Map<String, dynamic> json) {
+    return _$VerifyResetCodeResponseDtoFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() {
+    return _$VerifyResetCodeResponseDtoToJson(this);
+  }
+
+  VerifyResetCodeResponseEntity toEntity() {
+    return VerifyResetCodeResponseEntity(status: status);
+  }
+}

--- a/lib/features/auth/data/repositories/auth_repo_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repo_impl.dart
@@ -5,21 +5,31 @@ import 'package:online_exam/core/errors/api_results.dart';
 import 'package:online_exam/core/errors/failure.dart';
 import 'package:online_exam/core/errors/failures.dart';
 import 'package:online_exam/features/auth/data/data_sources/auth_remote_ds.dart';
+import 'package:online_exam/features/auth/data/models/forget_password/forget_password_input_model.dart';
 import 'package:online_exam/features/auth/data/models/login/login_request.dart';
 import 'package:online_exam/features/auth/data/models/userInputModels/register_input_model.dart';
 import 'package:online_exam/features/auth/data/models/userModel/user_model.dart';
 import 'package:online_exam/features/auth/domain/entities/login/user_entity.dart';
 import 'package:online_exam/features/auth/domain/repositories/auth_repo.dart';
 
+import '../../domain/entities/forget_password/forget_password_response_entity.dart';
+import '../../domain/entities/forget_password/reset_password_response_entity.dart';
+import '../../domain/entities/forget_password/verify_reset_code_response_entity.dart';
+import '../models/forget_password/email_verification_input_model.dart';
+import '../models/forget_password/forget_password_response_dto.dart';
+import '../models/forget_password/reset_password_input_model.dart';
+import '../models/forget_password/reset_password_response_dto.dart';
+import '../models/forget_password/verify_reset_code_response_dto.dart';
+
 @Injectable(as: AuthRepository)
 class AuthRepositoryImpl implements AuthRepository {
-  AuthRemoteDataSource dataSource;
+  final AuthRemoteDataSource _dataSource;
 
-  AuthRepositoryImpl(this.dataSource);
+  AuthRepositoryImpl(this._dataSource);
 
   @override
   Future<Either<Failures, UserEntity>> signIn(LoginRequest loginRequest) async {
-    var response = await dataSource.signIn(loginRequest);
+    var response = await _dataSource.signIn(loginRequest);
     return response.fold(
       (error) => Left(error),
       (response) => Right(response.toEntity()),
@@ -31,7 +41,7 @@ class AuthRepositoryImpl implements AuthRepository {
     RegisterInputModel registerInputModel,
   ) async {
     try {
-      UserModelDto result = await dataSource.signUp(registerInputModel);
+      UserModelDto result = await _dataSource.signUp(registerInputModel);
       return ApiSuccessResult<UserEntity>(data: result.user.toEntity());
     } on DioException catch (e) {
       return ApiErrorResult<UserEntity>(
@@ -39,6 +49,66 @@ class AuthRepositoryImpl implements AuthRepository {
       );
     } catch (e) {
       return ApiErrorResult<UserEntity>(
+        failure: Failure(errorMessage: e.toString()),
+      );
+    }
+  }
+
+  @override
+  Future<ApiResult<VerifyResetCodeResponseEntity>> confirmCode(
+      EmailVerificationInputModel resetCode,) async {
+    try {
+      VerifyResetCodeResponseDto result =
+      await _dataSource.confirmCode(resetCode);
+      return ApiSuccessResult<VerifyResetCodeResponseEntity>(
+        data: result.toEntity(),
+      );
+    } on DioException catch (e) {
+      return ApiErrorResult<VerifyResetCodeResponseEntity>(
+        failure: ServerFailure.fromDioError(dioException: e),
+      );
+    } catch (e) {
+      return ApiErrorResult<VerifyResetCodeResponseEntity>(
+        failure: Failure(errorMessage: e.toString()),
+      );
+    }
+  }
+
+  @override
+  Future<ApiResult<ForgetPasswordResponseEntity>> requestPasswordReset(
+      ForgetPasswordInputModel email,) async {
+    try {
+      ForgetPasswordResponseDto result = await _dataSource.requestPasswordReset(
+          email);
+      return ApiSuccessResult<ForgetPasswordResponseEntity>(
+        data: result.toEntity(),
+      );
+    } on DioException catch (e) {
+      return ApiErrorResult<ForgetPasswordResponseEntity>(
+        failure: ServerFailure.fromDioError(dioException: e),
+      );
+    } catch (e) {
+      return ApiErrorResult<ForgetPasswordResponseEntity>(
+        failure: Failure(errorMessage: e.toString()),
+      );
+    }
+  }
+
+  @override
+  Future<ApiResult<ResetPasswordResponseEntity>> resetPassword(
+      ResetPasswordInputModel resetPasswordInputModel,) async {
+    try {
+      ResetPasswordResponseDto result =
+      await _dataSource.resetPassword(resetPasswordInputModel);
+      return ApiSuccessResult<ResetPasswordResponseEntity>(
+        data: result.toEntity(),
+      );
+    } on DioException catch (e) {
+      return ApiErrorResult<ResetPasswordResponseEntity>(
+        failure: ServerFailure.fromDioError(dioException: e),
+      );
+    } catch (e) {
+      return ApiErrorResult<ResetPasswordResponseEntity>(
         failure: Failure(errorMessage: e.toString()),
       );
     }

--- a/lib/features/auth/domain/entities/forget_password/forget_password_response_entity.dart
+++ b/lib/features/auth/domain/entities/forget_password/forget_password_response_entity.dart
@@ -1,0 +1,6 @@
+class ForgetPasswordResponseEntity {
+  ForgetPasswordResponseEntity({this.message, this.info});
+
+  String? message;
+  String? info;
+}

--- a/lib/features/auth/domain/entities/forget_password/reset_password_response_entity.dart
+++ b/lib/features/auth/domain/entities/forget_password/reset_password_response_entity.dart
@@ -1,0 +1,6 @@
+class ResetPasswordResponseEntity {
+  ResetPasswordResponseEntity({this.message, this.token});
+
+  String? message;
+  String? token;
+}

--- a/lib/features/auth/domain/entities/forget_password/verify_reset_code_response_entity.dart
+++ b/lib/features/auth/domain/entities/forget_password/verify_reset_code_response_entity.dart
@@ -1,0 +1,5 @@
+class VerifyResetCodeResponseEntity {
+  VerifyResetCodeResponseEntity({this.status});
+
+  String? status;
+}

--- a/lib/features/auth/domain/repositories/auth_repo.dart
+++ b/lib/features/auth/domain/repositories/auth_repo.dart
@@ -1,12 +1,27 @@
 import 'package:dartz/dartz.dart';
 import 'package:online_exam/core/errors/api_results.dart';
+import 'package:online_exam/features/auth/data/models/forget_password/forget_password_input_model.dart';
 import 'package:online_exam/features/auth/data/models/userInputModels/register_input_model.dart';
 import 'package:online_exam/features/auth/domain/entities/login/user_entity.dart';
+
 import '../../../../core/errors/failures.dart';
+import '../../data/models/forget_password/email_verification_input_model.dart';
+import '../../data/models/forget_password/reset_password_input_model.dart';
 import '../../data/models/login/login_request.dart';
+import '../entities/forget_password/forget_password_response_entity.dart';
+import '../entities/forget_password/reset_password_response_entity.dart';
+import '../entities/forget_password/verify_reset_code_response_entity.dart';
 
-abstract class AuthRepository {
+abstract interface class AuthRepository {
   Future<Either<Failures, UserEntity>> signIn(LoginRequest loginRequest);
-
   Future<ApiResult<UserEntity>> signUp(RegisterInputModel registerInputModel);
+
+  Future<ApiResult<ForgetPasswordResponseEntity>> requestPasswordReset(
+      ForgetPasswordInputModel email);
+
+  Future<ApiResult<VerifyResetCodeResponseEntity>> confirmCode(
+      EmailVerificationInputModel resetCode);
+
+  Future<ApiResult<ResetPasswordResponseEntity>> resetPassword(
+      ResetPasswordInputModel resetPasswordInputModel);
 }

--- a/lib/features/auth/domain/use_cases/confirm_code_use_case.dart
+++ b/lib/features/auth/domain/use_cases/confirm_code_use_case.dart
@@ -1,0 +1,19 @@
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/errors/api_results.dart';
+import '../../data/models/forget_password/email_verification_input_model.dart';
+import '../entities/forget_password/verify_reset_code_response_entity.dart';
+import '../repositories/auth_repo.dart';
+
+@injectable
+class ConfirmCodeUseCase {
+  final AuthRepository _authRepository;
+
+  ConfirmCodeUseCase(this._authRepository);
+
+  Future<ApiResult<VerifyResetCodeResponseEntity>> invoke(
+    EmailVerificationInputModel resetCode,
+  ) {
+    return _authRepository.confirmCode(resetCode);
+  }
+}

--- a/lib/features/auth/domain/use_cases/request_password_reset_use_case.dart
+++ b/lib/features/auth/domain/use_cases/request_password_reset_use_case.dart
@@ -1,0 +1,19 @@
+import 'package:injectable/injectable.dart';
+import 'package:online_exam/features/auth/data/models/forget_password/forget_password_input_model.dart';
+
+import '../../../../core/errors/api_results.dart';
+import '../entities/forget_password/forget_password_response_entity.dart';
+import '../repositories/auth_repo.dart';
+
+@injectable
+class RequestPasswordResetUseCase {
+  final AuthRepository _authRepository;
+
+  RequestPasswordResetUseCase(this._authRepository);
+
+  Future<ApiResult<ForgetPasswordResponseEntity>> invoke(
+    ForgetPasswordInputModel email,
+  ) {
+    return _authRepository.requestPasswordReset(email);
+  }
+}

--- a/lib/features/auth/domain/use_cases/reset_password_use_case.dart
+++ b/lib/features/auth/domain/use_cases/reset_password_use_case.dart
@@ -1,0 +1,19 @@
+import 'package:injectable/injectable.dart';
+import 'package:online_exam/features/auth/domain/repositories/auth_repo.dart';
+
+import '../../../../core/errors/api_results.dart';
+import '../../data/models/forget_password/reset_password_input_model.dart';
+import '../entities/forget_password/reset_password_response_entity.dart';
+
+@injectable
+class ResetPasswordUseCase {
+  final AuthRepository _repository;
+
+  ResetPasswordUseCase(this._repository);
+
+  Future<ApiResult<ResetPasswordResponseEntity>> invoke(
+    ResetPasswordInputModel resetPasswordInputModel,
+  ) {
+    return _repository.resetPassword(resetPasswordInputModel);
+  }
+}

--- a/lib/features/auth/presentation/manager/forget_password/forget_password_cubit.dart
+++ b/lib/features/auth/presentation/manager/forget_password/forget_password_cubit.dart
@@ -1,0 +1,167 @@
+import 'package:bloc/bloc.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:injectable/injectable.dart';
+import 'package:online_exam/core/errors/api_results.dart';
+import 'package:online_exam/features/auth/data/models/forget_password/forget_password_input_model.dart';
+import 'package:online_exam/features/auth/domain/entities/forget_password/forget_password_response_entity.dart';
+import 'package:online_exam/features/auth/domain/use_cases/confirm_code_use_case.dart';
+import 'package:online_exam/features/auth/domain/use_cases/request_password_reset_use_case.dart';
+import 'package:online_exam/features/auth/domain/use_cases/reset_password_use_case.dart';
+import 'package:online_exam/features/auth/presentation/manager/forget_password/forget_password_event.dart';
+
+import '../../../data/models/forget_password/email_verification_input_model.dart';
+import '../../../data/models/forget_password/reset_password_input_model.dart';
+import '../../../domain/entities/forget_password/reset_password_response_entity.dart';
+import '../../../domain/entities/forget_password/verify_reset_code_response_entity.dart';
+import 'forget_password_state.dart';
+
+@injectable
+class ForgetPasswordCubit extends Cubit<ForgetPasswordState> {
+  ForgetPasswordCubit(
+    this.confirmCodeUseCase,
+    this.requestPasswordResetUseCase,
+    this.resetPasswordUseCase,
+  ) : super(ForgetPasswordState());
+
+  final ConfirmCodeUseCase confirmCodeUseCase;
+  final RequestPasswordResetUseCase requestPasswordResetUseCase;
+  final ResetPasswordUseCase resetPasswordUseCase;
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
+  final TextEditingController emailController = TextEditingController(
+    text: "anaa71137@gmail.com",
+  );
+  final TextEditingController codeController = TextEditingController();
+  final TextEditingController newPassController = TextEditingController(
+    text: "A7medfayed",
+  );
+  String _email = '';
+
+  doIntent(ForgetPasswordEvent event) {
+    switch (event) {
+      case RequestPasswordResetEvent():
+        _requestPasswordReset(
+          ForgetPasswordInputModel(email: emailController.text),
+        );
+        break;
+      case ConfirmCodeEvent():
+        _confirmCode(EmailVerificationInputModel(code: codeController.text));
+        break;
+      case ResetPasswordEvent():
+        _resetPassword(
+          ResetPasswordInputModel(
+            email: emailController.text,
+            confirmPass: newPassController.text,
+          ),
+        );
+        break;
+      case ResendCodeEvent():
+        _resendCode(ForgetPasswordInputModel(email: _email));
+        break;
+    }
+  }
+
+  Future<void> _requestPasswordReset(ForgetPasswordInputModel email) async {
+    if (formKey.currentState?.validate() == true) {
+      emit(state.copyWith(isLoadingRequestPasswordReset: true));
+      ApiResult<ForgetPasswordResponseEntity> result =
+          await requestPasswordResetUseCase.invoke(email);
+      switch (result) {
+        case ApiSuccessResult<ForgetPasswordResponseEntity>():
+          _email = emailController.text;
+          emit(
+            state.copyWith(
+              isLoadingRequestPasswordReset: false,
+              successRequestPasswordReset: result.data.message,
+            ),
+          );
+          break;
+
+        case ApiErrorResult<ForgetPasswordResponseEntity>():
+          emit(
+            state.copyWith(
+              isLoadingRequestPasswordReset: false,
+              errorRequestPasswordReset: result.failure.errorMessage,
+            ),
+          );
+          break;
+      }
+    }
+  }
+
+  Future<void> _confirmCode(EmailVerificationInputModel code) async {
+    emit(state.copyWith(isLoadingConfirmCode: true));
+    ApiResult<VerifyResetCodeResponseEntity> result = await confirmCodeUseCase
+        .invoke(code);
+    switch (result) {
+      case ApiSuccessResult<VerifyResetCodeResponseEntity>():
+        emit(
+          state.copyWith(
+            isLoadingConfirmCode: false,
+            successConfirmCode: result.data.status,
+          ),
+        );
+        break;
+
+      case ApiErrorResult<VerifyResetCodeResponseEntity>():
+        emit(
+          state.copyWith(
+            isLoadingConfirmCode: false,
+            errorConfirmCode: result.failure.errorMessage,
+            invalidCode: true,
+          ),
+        );
+        break;
+    }
+  }
+
+  Future<void> _resetPassword(ResetPasswordInputModel model) async {
+    emit(state.copyWith(isLoadingResetPassword: true));
+    ApiResult<ResetPasswordResponseEntity> result = await resetPasswordUseCase
+        .invoke(model);
+    switch (result) {
+      case ApiSuccessResult<ResetPasswordResponseEntity>():
+        emit(
+          state.copyWith(
+            isLoadingResetPassword: false,
+            successResetPassword: result.data.message,
+          ),
+        );
+        break;
+
+      case ApiErrorResult<ResetPasswordResponseEntity>():
+        emit(
+          state.copyWith(
+            isLoadingResetPassword: false,
+            errorResetPassword: result.failure.errorMessage,
+          ),
+        );
+        break;
+    }
+  }
+
+  Future<void> _resendCode(ForgetPasswordInputModel email) async {
+    emit(state.copyWith(isLoadingResendCode: true));
+    ApiResult<ForgetPasswordResponseEntity> result =
+        await requestPasswordResetUseCase.invoke(email);
+    switch (result) {
+      case ApiSuccessResult<ForgetPasswordResponseEntity>():
+        emit(
+          state.copyWith(
+            isLoadingResendCode: false,
+            successRequestPasswordReset: result.data.message,
+          ),
+        );
+        break;
+
+      case ApiErrorResult<ForgetPasswordResponseEntity>():
+        emit(
+          state.copyWith(
+            isLoadingResendCode: false,
+            errorRequestPasswordReset: result.failure.errorMessage,
+          ),
+        );
+        break;
+    }
+  }
+}

--- a/lib/features/auth/presentation/manager/forget_password/forget_password_event.dart
+++ b/lib/features/auth/presentation/manager/forget_password/forget_password_event.dart
@@ -1,0 +1,9 @@
+sealed class ForgetPasswordEvent {}
+
+class RequestPasswordResetEvent extends ForgetPasswordEvent {}
+
+class ResetPasswordEvent extends ForgetPasswordEvent {}
+
+class ConfirmCodeEvent extends ForgetPasswordEvent {}
+
+class ResendCodeEvent extends ForgetPasswordEvent {}

--- a/lib/features/auth/presentation/manager/forget_password/forget_password_state.dart
+++ b/lib/features/auth/presentation/manager/forget_password/forget_password_state.dart
@@ -1,0 +1,61 @@
+class ForgetPasswordState {
+  bool isLoadingResetPassword = false;
+  bool isLoadingConfirmCode = false;
+  bool isLoadingRequestPasswordReset = false;
+  bool isLoadingResendCode = false;
+  bool invalidCode = false;
+
+  String? errorRequestPasswordReset;
+  String? errorConfirmCode;
+  String? errorResetPassword;
+
+  String? successRequestPasswordReset;
+  String? successConfirmCode;
+  String? successResetPassword;
+
+  ForgetPasswordState({
+    this.isLoadingResetPassword = false,
+    this.isLoadingConfirmCode = false,
+    this.isLoadingRequestPasswordReset = false,
+    this.isLoadingResendCode = false,
+    this.invalidCode = false,
+    this.errorRequestPasswordReset,
+    this.errorConfirmCode,
+    this.errorResetPassword,
+    this.successRequestPasswordReset,
+    this.successConfirmCode,
+    this.successResetPassword,
+  });
+
+  ForgetPasswordState copyWith({
+    bool? isLoadingResetPassword,
+    bool? isLoadingConfirmCode,
+    bool? isLoadingRequestPasswordReset,
+    bool? isLoadingResendCode,
+    bool? invalidCode,
+    String? errorRequestPasswordReset,
+    String? errorConfirmCode,
+    String? errorResetPassword,
+    String? successRequestPasswordReset,
+    String? successConfirmCode,
+    String? successResetPassword,
+  }) {
+    return ForgetPasswordState(
+      isLoadingResetPassword:
+          isLoadingResetPassword ?? this.isLoadingResetPassword,
+      isLoadingConfirmCode: isLoadingConfirmCode ?? this.isLoadingConfirmCode,
+      isLoadingRequestPasswordReset:
+          isLoadingRequestPasswordReset ?? this.isLoadingRequestPasswordReset,
+      isLoadingResendCode: isLoadingResendCode ?? this.isLoadingResendCode,
+      invalidCode: invalidCode ?? this.invalidCode,
+      errorRequestPasswordReset:
+          errorRequestPasswordReset ?? this.errorRequestPasswordReset,
+      errorConfirmCode: errorConfirmCode ?? this.errorConfirmCode,
+      errorResetPassword: errorResetPassword ?? this.errorResetPassword,
+      successRequestPasswordReset:
+          successRequestPasswordReset ?? this.successRequestPasswordReset,
+      successConfirmCode: successConfirmCode ?? this.successConfirmCode,
+      successResetPassword: successResetPassword ?? this.successResetPassword,
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/forget_password_screen.dart
+++ b/lib/features/auth/presentation/pages/forget_password_screen.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:online_exam/config/routing/app_routes.dart';
+import 'package:online_exam/config/routing/routing_extensions.dart';
+import 'package:online_exam/config/theme/colors.dart';
+import 'package:online_exam/core/helpers/dialogue_utils.dart';
+import 'package:online_exam/core/helpers/flutter_toast.dart';
+import 'package:online_exam/core/l10n/translations/app_localizations.dart';
+import 'package:online_exam/features/auth/presentation/manager/forget_password/forget_password_cubit.dart';
+import 'package:online_exam/features/auth/presentation/manager/forget_password/forget_password_state.dart';
+import 'package:online_exam/features/auth/presentation/widgets/Email_verification_widget.dart';
+import 'package:online_exam/features/auth/presentation/widgets/forget_password_widget.dart';
+import 'package:online_exam/features/auth/presentation/widgets/reset_password_widget.dart';
+
+import '../../../../core/di/di.dart';
+import '../manager/forget_password/forget_password_event.dart';
+
+class ForgetPasswordScreen extends StatefulWidget {
+  const ForgetPasswordScreen({super.key});
+
+  @override
+  State<ForgetPasswordScreen> createState() => _ForgetPasswordScreenState();
+}
+
+class _ForgetPasswordScreenState extends State<ForgetPasswordScreen> {
+  final PageController _controller = PageController();
+  final ForgetPasswordCubit viewModel = getIt<ForgetPasswordCubit>();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => viewModel,
+      child: BlocListener<ForgetPasswordCubit, ForgetPasswordState>(
+        listener: (context, state) {
+          if (state.errorRequestPasswordReset != null) {
+            DialogueUtils.showMessage(
+              context: context,
+              message: state.errorRequestPasswordReset ?? '',
+              title: AppLocalizations.of(context)!.error,
+              posActionName: AppLocalizations.of(context)!.ok,
+            );
+            state.errorRequestPasswordReset = null;
+          }
+
+          if (state.errorConfirmCode != null) {
+            DialogueUtils.showMessage(
+              context: context,
+              message: state.errorConfirmCode ?? '',
+              title: AppLocalizations.of(context)!.error,
+              posActionName: AppLocalizations.of(context)!.ok,
+            );
+            state.errorConfirmCode = null;
+          }
+
+          if (state.errorResetPassword != null) {
+            DialogueUtils.showMessage(
+              context: context,
+              message: state.errorResetPassword ?? '',
+              title: AppLocalizations.of(context)!.error,
+              posActionName: AppLocalizations.of(context)!.ok,
+            );
+            state.errorResetPassword = null;
+          }
+
+          if (state.successRequestPasswordReset != null) {
+            _controller.jumpToPage(1);
+          }
+
+          if (state.successConfirmCode != null) {
+            _controller.jumpToPage(2);
+          }
+
+          if (state.successResetPassword != null) {
+            context.pushNamedAndRemoveUntil(
+              AppRoutes.signInRoute,
+              predicate: (_) => false,
+            );
+          }
+        },
+        child: Scaffold(
+          appBar: AppBar(title: Text(AppLocalizations.of(context)!.password)),
+          body: Padding(
+            padding: REdgeInsets.symmetric(vertical: 40, horizontal: 16),
+            child: PageView(
+              controller: _controller,
+              children: [
+                ForgetPasswordWidget(
+                  sendCode: sendCode,
+                  formKey: viewModel.formKey,
+                  emailController: viewModel.emailController,
+                ),
+                BlocSelector<ForgetPasswordCubit, ForgetPasswordState, bool>(
+                  selector: (state) => state.invalidCode,
+                  builder: (context, invalidCode) {
+                    return EmailVerificationWidget(
+                      onSubmit: onSubmit,
+                      invalidCode: invalidCode,
+                      resend: () {
+                        reSendCode();
+                        ToastMessage.toastMsg(
+                          AppLocalizations.of(
+                            context,
+                          )!.code_resend_successfully,
+                          Colors.green,
+                          AppColors.white,
+                        );
+                      },
+                    );
+                  },
+                ),
+                ResetPasswordWidget(
+                  resetPassword: resetPassword,
+                  emailController: viewModel.emailController,
+                  newPassController: viewModel.newPassController,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  sendCode() {
+    viewModel.doIntent(RequestPasswordResetEvent());
+  }
+
+  reSendCode() {
+    viewModel.doIntent(ResendCodeEvent());
+  }
+
+  onSubmit(String code) {
+    viewModel.codeController.text = code;
+    viewModel.doIntent(ConfirmCodeEvent());
+  }
+
+  resetPassword() {
+    viewModel.doIntent(ResetPasswordEvent());
+  }
+}

--- a/lib/features/auth/presentation/widgets/email_verification_widget.dart
+++ b/lib/features/auth/presentation/widgets/email_verification_widget.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:online_exam/features/auth/presentation/widgets/otp_text_field_widget.dart';
+
+import '../../../../core/helpers/spacing.dart';
+import '../../../../core/l10n/translations/app_localizations.dart';
+
+class EmailVerificationWidget extends StatelessWidget {
+  const EmailVerificationWidget({
+    super.key,
+    required this.onSubmit,
+    required this.invalidCode,
+    required this.resend,
+  });
+
+  final void Function(String) onSubmit;
+  final bool invalidCode;
+  final void Function() resend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          AppLocalizations.of(context)!.email_verification,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyLarge!.copyWith(fontSize: 18.sp),
+        ),
+        verticalSpace(16),
+        Text(
+          AppLocalizations.of(context)!.enter_verification_code,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        verticalSpace(32),
+        Column(
+          spacing: 5.h,
+          children: [
+            OtpTextFieldWidget(onSubmit: onSubmit, invalidCode: invalidCode),
+            invalidCode
+                ? Row(
+                    spacing: 5.w,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Icon(Icons.error_outline, color: Colors.red, size: 17.sp),
+                      Text(AppLocalizations.of(context)!.invalid_code),
+                    ],
+                  )
+                : const SizedBox.shrink(),
+          ],
+        ),
+        verticalSpace(32),
+        RichText(
+          text: TextSpan(
+            children: [
+              TextSpan(
+                text: AppLocalizations.of(context)!.didnt_receive_code,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              TextSpan(
+                text: AppLocalizations.of(context)!.resend,
+                style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                  decoration: TextDecoration.underline,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                recognizer: TapGestureRecognizer()..onTap = resend,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/forget_password_widget.dart
+++ b/lib/features/auth/presentation/widgets/forget_password_widget.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:online_exam/core/helpers/spacing.dart';
+import 'package:online_exam/core/helpers/validators.dart';
+import 'package:online_exam/core/l10n/translations/app_localizations.dart';
+
+class ForgetPasswordWidget extends StatelessWidget {
+  const ForgetPasswordWidget({
+    super.key,
+    required this.sendCode,
+    required this.formKey,
+    required this.emailController,
+  });
+
+  final void Function() sendCode;
+  final GlobalKey<FormState> formKey;
+  final TextEditingController emailController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          AppLocalizations.of(context)!.forget_password,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyLarge!.copyWith(fontSize: 18.sp),
+        ),
+        verticalSpace(16),
+        Text(
+          AppLocalizations.of(context)!.enter_associated_email,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        verticalSpace(32),
+        Form(
+          key: formKey,
+          child: TextFormField(
+            controller: emailController,
+            validator: Validations.validateEmail,
+            decoration: InputDecoration(
+              labelText: AppLocalizations.of(context)!.email,
+              hintText: AppLocalizations.of(context)!.enter_your_email,
+            ),
+          ),
+        ),
+        verticalSpace(48),
+        ElevatedButton(
+          onPressed: sendCode,
+          child: Text(AppLocalizations.of(context)!.continue_word),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/otp_text_field_widget.dart
+++ b/lib/features/auth/presentation/widgets/otp_text_field_widget.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_otp_text_field/flutter_otp_text_field.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:online_exam/config/theme/colors.dart';
+
+import '../../../../core/utils/font_weight.dart';
+
+class OtpTextFieldWidget extends StatelessWidget {
+  const OtpTextFieldWidget({
+    super.key,
+    required this.onSubmit,
+    required this.invalidCode,
+  });
+
+  final void Function(String) onSubmit;
+  final bool invalidCode;
+
+  @override
+  Widget build(BuildContext context) {
+    return OtpTextField(
+      numberOfFields: 6,
+      borderColor: !invalidCode ? Colors.transparent : Colors.red,
+      focusedBorderColor: !invalidCode ? Colors.transparent : Colors.red,
+      enabledBorderColor: !invalidCode ? Colors.transparent : Colors.red,
+      disabledBorderColor: !invalidCode ? Colors.transparent : Colors.red,
+      filled: true,
+      fillColor: AppColors.otpFieldBorderColor,
+      borderRadius: BorderRadius.circular(8),
+      fieldWidth: 45.w,
+      fieldHeight: 60.h,
+      decoration: InputDecoration(
+        labelStyle: TextStyle(
+          fontSize: 16.sp,
+          fontWeight: AppFontWeight.medium,
+          color: AppColors.grey,
+        ),
+      ),
+      keyboardType: TextInputType.number,
+      showFieldAsBox: true,
+      onSubmit: onSubmit,
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/remember_me_and_forget_password.dart
+++ b/lib/features/auth/presentation/widgets/remember_me_and_forget_password.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:online_exam/config/routing/app_routes.dart';
+import 'package:online_exam/config/routing/routing_extensions.dart';
+
 import '../../../../core/l10n/translations/app_localizations.dart';
 
 class RememberMeAndForgetPassword extends StatelessWidget {
@@ -29,7 +32,7 @@ class RememberMeAndForgetPassword extends StatelessWidget {
         ),
         TextButton(
           onPressed: () {
-            //todo: navigate to forget pass screen
+            context.pushNamed(AppRoutes.forgetPasswordRoute);
           },
           child: Text(
             '${AppLocalizations.of(context)!.forget_password}?',

--- a/lib/features/auth/presentation/widgets/reset_password_widget.dart
+++ b/lib/features/auth/presentation/widgets/reset_password_widget.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../core/helpers/spacing.dart';
+import '../../../../core/l10n/translations/app_localizations.dart';
+
+class ResetPasswordWidget extends StatelessWidget {
+  const ResetPasswordWidget({
+    super.key,
+    required this.resetPassword,
+    required this.emailController,
+    required this.newPassController,
+  });
+
+  final void Function() resetPassword;
+  final TextEditingController emailController;
+  final TextEditingController newPassController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          AppLocalizations.of(context)!.reset_password,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyLarge!.copyWith(fontSize: 18.sp),
+        ),
+        verticalSpace(16),
+        Text(
+          AppLocalizations.of(context)!.password_validation,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        verticalSpace(32),
+        TextFormField(
+          controller: emailController,
+          decoration: InputDecoration(
+            labelText: AppLocalizations.of(context)!.email,
+            hintText: AppLocalizations.of(context)!.enter_your_email,
+          ),
+        ),
+        verticalSpace(24),
+        TextFormField(
+          controller: newPassController,
+          decoration: InputDecoration(
+            labelText: AppLocalizations.of(context)!.new_password,
+            hintText: AppLocalizations.of(context)!.new_password,
+          ),
+        ),
+        verticalSpace(48),
+        ElevatedButton(
+          onPressed: resetPassword,
+          child: Text(AppLocalizations.of(context)!.continue_word),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/main_layout/explore/data/datasources/remote_data_source.dart
+++ b/lib/features/main_layout/explore/data/datasources/remote_data_source.dart
@@ -2,5 +2,5 @@ import 'package:online_exam/core/errors/api_results.dart';
 import 'package:online_exam/features/main_layout/explore/domain/entities/subject_entity.dart';
 
 abstract interface class ExploreRemoteDataSource {
-  Future<ApiResult<List<SubjectEntity>>> getSubjects({required String token});
+  Future<ApiResult<List<SubjectEntity>>> getSubjects();
 }

--- a/lib/features/main_layout/explore/data/datasources/remote_data_source_impl.dart
+++ b/lib/features/main_layout/explore/data/datasources/remote_data_source_impl.dart
@@ -14,11 +14,9 @@ class ExploreRemoteDataSourceImpl implements ExploreRemoteDataSource {
   ExploreRemoteDataSourceImpl(this._apiServices);
 
   @override
-  Future<ApiResult<List<SubjectEntity>>> getSubjects({
-    required String token,
-  }) async {
+  Future<ApiResult<List<SubjectEntity>>> getSubjects() async {
     try {
-      SubjectsDto subjectsDto = await _apiServices.getSubjects(token);
+      SubjectsDto subjectsDto = await _apiServices.getSubjects();
 
       List<SubjectEntity> subjectsEntityList =
           subjectsDto.subjects?.map((subject) => subject.toEntity()).toList() ??

--- a/lib/features/main_layout/explore/data/repositories/repo_impl.dart
+++ b/lib/features/main_layout/explore/data/repositories/repo_impl.dart
@@ -10,11 +10,9 @@ class ExploreRepositoryImpl implements ExploreRepository {
   ExploreRepositoryImpl(this._remoteDataSource);
 
   @override
-  Future<ApiResult<List<SubjectEntity>>> getSubjects({
-    required String token,
-  }) async {
+  Future<ApiResult<List<SubjectEntity>>> getSubjects() async {
     ApiResult<List<SubjectEntity>> response = await _remoteDataSource
-        .getSubjects(token: token);
+        .getSubjects();
     return response;
   }
 }

--- a/lib/features/main_layout/explore/domain/repositories/repo.dart
+++ b/lib/features/main_layout/explore/domain/repositories/repo.dart
@@ -2,5 +2,5 @@ import 'package:online_exam/core/errors/api_results.dart';
 import 'package:online_exam/features/main_layout/explore/domain/entities/subject_entity.dart';
 
 abstract interface class ExploreRepository {
-  Future<ApiResult<List<SubjectEntity>>> getSubjects({required String token});
+  Future<ApiResult<List<SubjectEntity>>> getSubjects();
 }

--- a/lib/features/main_layout/explore/domain/usecases/get_subjects_use_case.dart
+++ b/lib/features/main_layout/explore/domain/usecases/get_subjects_use_case.dart
@@ -9,6 +9,6 @@ class GetSubjectsUseCase {
   final ExploreRepository _subjectRepository;
   GetSubjectsUseCase(this._subjectRepository);
 
-  Future<ApiResult<List<SubjectEntity>>> invoke({required String token}) =>
-      _subjectRepository.getSubjects(token: token);
+  Future<ApiResult<List<SubjectEntity>>> invoke() =>
+      _subjectRepository.getSubjects();
 }

--- a/lib/features/main_layout/explore/presentation/manger/cubit/explore_cubit.dart
+++ b/lib/features/main_layout/explore/presentation/manger/cubit/explore_cubit.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 import 'package:online_exam/core/errors/api_results.dart';
 import 'package:online_exam/features/main_layout/explore/domain/entities/subject_entity.dart';
 import 'package:online_exam/features/main_layout/explore/domain/usecases/get_subjects_use_case.dart';
+
 part 'explore_state.dart';
 
 @Injectable()
@@ -11,9 +12,9 @@ class ExploreCubit extends Cubit<ExploreState> {
   final GetSubjectsUseCase _getSubjectsUseCase;
   ExploreCubit(this._getSubjectsUseCase) : super(ExploreInitial());
 
-  Future<void> getSubjects({required String token}) async {
+  Future<void> getSubjects() async {
     emit(ExploreLoadingState());
-    final result = await _getSubjectsUseCase.invoke(token: token);
+    final result = await _getSubjectsUseCase.invoke();
     switch (result) {
       case ApiSuccessResult<List<SubjectEntity>>():
         emit(ExploreSuccessState(subjects: result.data));

--- a/lib/features/main_layout/main_layout.dart
+++ b/lib/features/main_layout/main_layout.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:online_exam/core/di/di.dart';
-import 'package:online_exam/core/helpers/shared_pref.dart';
-import 'package:online_exam/core/network/api_constants.dart';
 import 'package:online_exam/features/main_layout/explore/presentation/manger/cubit/explore_cubit.dart';
-import 'package:online_exam/features/main_layout/widgets/button_nav_bar.dart';
 import 'package:online_exam/features/main_layout/explore/presentation/pages/explore_screen.dart';
+import 'package:online_exam/features/main_layout/profile/presentation/pages/profile_screen.dart';
+import 'package:online_exam/features/main_layout/widgets/button_nav_bar.dart';
 
 class MainLayout extends StatefulWidget {
   const MainLayout({super.key});
@@ -31,15 +30,11 @@ class _MainLayoutState extends State<MainLayout> {
         index: currentIndex,
         children: [
           BlocProvider(
-            create: (context) => getIt.get<ExploreCubit>()
-              ..getSubjects(
-                token:
-                    SharedPrefHelper.getData(key: ApiConstants.token) as String,
-              ),
+            create: (context) => getIt.get<ExploreCubit>()..getSubjects(),
             child: const ExploreScreen(),
           ),
           const Center(child: Text('result')),
-          const Center(child: Text('profile')),
+          const Center(child: ProfileScreen()),
         ],
       ),
     );

--- a/lib/features/main_layout/profile/presentation/pages/profile_screen.dart
+++ b/lib/features/main_layout/profile/presentation/pages/profile_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:online_exam/config/routing/app_routes.dart';
+import 'package:online_exam/config/routing/routing_extensions.dart';
+import 'package:online_exam/core/helpers/shared_pref.dart';
+import 'package:online_exam/core/utils/app_constants.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: () {
+          context.pushNamedAndRemoveUntil(
+            AppRoutes.signInRoute,
+            predicate: (_) => false,
+          );
+          SharedPrefHelper.removeData(key: AppConstants.isRemember);
+        },
+        child: const Text("Logout"),
+      ),
+    );
+  }
+}

--- a/lib/features/subject_exams/data/data_sources/get_all_exams_ds_impl.dart
+++ b/lib/features/subject_exams/data/data_sources/get_all_exams_ds_impl.dart
@@ -1,12 +1,11 @@
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:online_exam/core/errors/api_results.dart';
-import 'package:online_exam/core/helpers/shared_pref.dart';
 import 'package:online_exam/core/network/api_services.dart';
-import 'package:online_exam/core/utils/app_constants.dart';
 import 'package:online_exam/features/subject_exams/data/data_sources/get_all_exams_ds.dart';
 import 'package:online_exam/features/subject_exams/data/model/get_exams_on_subject_dto.dart';
 import 'package:online_exam/features/subject_exams/domain/entities/exams_on_subject_entity.dart';
+
 import '../../../../core/errors/failure.dart';
 
 @Injectable(as: GetAllExamsDataSource)
@@ -20,9 +19,7 @@ class GetAllExamsDataSourceImpl implements GetAllExamsDataSource {
     String subjectId,
   ) async {
     try {
-      final token = SharedPrefHelper.getData(key: AppConstants.token);
       GetExamsOnSubjectDto examsDto = await _apiServices.getExamsOnSubject(
-        token as String,
         subjectId,
       );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:online_exam/core/functions/initial_route.dart';
 import 'package:online_exam/core/helpers/shared_pref.dart';
-import 'package:online_exam/core/utils/app_constants.dart';
-import 'config/routing/app_routes.dart';
+
 import 'config/routing/route_generator.dart';
 import 'config/theme/app_theme.dart';
 import 'core/di/di.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   internet_connection_checker: ^3.0.1
   flutter_svg: ^2.2.0
   lottie: ^3.3.1
+  flutter_otp_text_field: ^1.5.1+1
 
 
 
@@ -52,11 +53,11 @@ flutter:
 
   assets:
     - Assets/images/
-    - assets/images/
-    - assets/svgs/
+    - assets/images/exam_test.png
+    - assets/images/home.svg
+    - assets/images/profile.svg
+    - assets/images/results.svg
     - assets/animations/
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
   # fonts:
   #   - family: Schyler
   #     fonts:


### PR DESCRIPTION
feat(forgot password): complete forgot password screens with UI and logic.

- Implemented Forgot Password flow using PageView for UI.
- Integrated Cubit with event handling via doIntent function.
- Refactored token usage by setting it in Dio module (dio.options.headers) instead of passing it in each API service call.
- Added a simple ElevatedButton for logout to test token handling changes.


<img width="273" height="297" alt="image" src="https://github.com/user-attachments/assets/6c630b87-2bdc-43df-bc62-53b090845043" />
<img width="276" height="346" alt="image" src="https://github.com/user-attachments/assets/8d9ef2d8-25e6-4df1-97e7-ed95dd43d088" />
<img width="275" height="282" alt="image" src="https://github.com/user-attachments/assets/ebdba4b1-1c6b-4c19-b022-bcb9acbd147a" />
<img width="276" height="334" alt="image" src="https://github.com/user-attachments/assets/e27ae06b-0041-440b-9d62-521f106d396e" />
<img width="275" height="533" alt="image" src="https://github.com/user-attachments/assets/0ffd5ea8-9809-4f77-af5c-1cc15e0838f6" />
<img width="272" height="322" alt="image" src="https://github.com/user-attachments/assets/98d78202-c67c-4fc0-8b88-8ecdcfbc868c" />

